### PR TITLE
fixed typos, updated broken links except for 2 links (see details)

### DIFF
--- a/orientation/notebooks/intro2ipy.ipynb
+++ b/orientation/notebooks/intro2ipy.ipynb
@@ -73,7 +73,7 @@
     "[7]: http://jupyter.org\n",
     "[8]: https://registry.hub.docker.com/repos/ipython/\n",
     "[9]: http://nbviewer.ipython.org/github/ipython/ipython/blob/master/examples/IPython%20Kernel/Rich%20Output.ipynb\n",
-    "[10]: http://nbviewer.ipython.org/github/ipython/ipython/blob/master/examples/Notebook/Notebook%20Basics.ipynb"
+    "[10]: https://nbviewer.jupyter.org/github/ipython/ipython/blob/4.0.x/examples/Notebook/Notebook%20Basics.ipynb"
    ]
   },
   {
@@ -296,7 +296,7 @@
     "If you are uncertain how to use a particular magic, you can always\n",
     "obtain help from the IPython kernel by entering the magic by itself in a\n",
     "cell, adding a `?` character at the end, and executing the cell to bring\n",
-    "up the IPython help window, as shown below for the `%writefile` magic.\n",
+    "up the IPython help window, as shown below for the `%%writefile` magic.\n",
     "\n",
     "![IPython magic help](images/ipython-help.png)\n",
     "\n",
@@ -377,7 +377,7 @@
     "\n",
     "Normally, you simply write text as normal for a document. Paragraphs are\n",
     "simply one or more lines that are enclosed in blank lines. If you need\n",
-    "to insert a line break between two lins of text (sometimes useful when\n",
+    "to insert a line break between two lines of text (sometimes useful when\n",
     "writing out lists), you simply add two or more blank spaces at the end\n",
     "of the line to break.\n",
     "\n",
@@ -510,7 +510,7 @@
     "[df]: http://daringfireball.net\n",
     "[1]: http://daringfireball.net/projects/markdown/\n",
     "[2]: http://daringfireball.net/projects/markdown/license\n",
-    "[3]: http://nbviewer.ipython.org/github/ipython/ipython/blob/master/examples/Notebook/Working%20With%20Markdown%20Cells.ipynb"
+    "[3]: https://nbviewer.jupyter.org/github/ipython/ipython/blob/4.0.x/examples/Notebook/Working%20With%20Markdown%20Cells.ipynb"
    ]
   },
   {
@@ -563,7 +563,7 @@
     "\n",
     "We [previously](1_unixdp.ipynb), we discussed how to perform different\n",
     "data science tasks at the Unix command line. We can actually execute\n",
-    "nearly all of thee commands from within the IPython Notebook, by using a\n",
+    "nearly all of the commands from within the IPython Notebook, by using a\n",
     "_Code Cell_ and preceding the Unix command by an exclamation point. For\n",
     "example, to display the current working directory, we would enter `!pwd`\n",
     "and subsequently execute this code cell. \n",
@@ -679,7 +679,7 @@
     "When making data visualization, the resulting plots or images can be\n",
     "displayed inline. The recommended way to accomplish this is to use the\n",
     "`%matplotlib` line magic, which will inform the IPython kernel to\n",
-    "display the image inline; this magiuc can take either the `inline` or\n",
+    "display the image inline; this magic can take either the `inline` or\n",
     "the `notebook` value, the `inline` value will generally be preferred in\n",
     "this class for simplicity. Note you may see suggestions to use the\n",
     "`%pylab` line magic, but this approach is no longer recommended since it\n",
@@ -803,8 +803,8 @@
    "source": [
     "### Additional References\n",
     "\n",
-    "1. [IPython videos]( http://ipython.org/videos.html).\n",
-    "2. [IPython documentation](http://ipython.org/ipython-doc/stable/index.html).\n",
+    "1. [IPython videos](https://ipython.org/presentation.html).\n",
+    "2. [IPython documentation](http://ipython.readthedocs.io/en/stable/).\n",
     "\n",
     "-----"
    ]
@@ -812,21 +812,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.0"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
-Fixed a couple of typos
-Updated broken links for:
1. “Notebook basics”
2. markdown notebook under 'Markdown cells'
3. **ipython videos to ipython presentations** (they probably refer to videos as presentations, unless I’m not understanding it correctly)
4. ipython doc.s link to point to the latest version

-**Broken links that I didn't change (I'm not sure what they point to):**
1.   under 'IPython Magics' : “specific commands” seems to be referring to some link that is not there
2.    under 'Unix Commands': “previously” is referring to a notebook that’s not in the orientation folder